### PR TITLE
Make implementation accessible in Android projects (to set the password)

### DIFF
--- a/Plugin.SecureStorage.Android/SecureStorageImplementation.cs
+++ b/Plugin.SecureStorage.Android/SecureStorageImplementation.cs
@@ -11,7 +11,7 @@ using System.Text;
 
 namespace Plugin.SecureStorage
 {
-    internal class SecureStorageImplementation : ISecureStorage
+    public class SecureStorageImplementation : ISecureStorage
     {
         private static readonly Lazy<IKey> EncryptionKey = new Lazy<IKey>(GetEncryptionKey);
         private static readonly byte[] EncryptionIV = Enumerable.Repeat(default(byte), 128).ToArray();


### PR DESCRIPTION
In order to allow an Android app project to set the secure storage password, the Android implementation should be made accessible and therefore made public.